### PR TITLE
fix: FCM error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Resolve APNS `:too_many_provider_token_updates` by moving token generation into
   `APNS.Token` ([#227](https://github.com/codedge-llc/pigeon/pull/227)).
 - Support HTTPoison 2.0. ([#236](https://github.com/codedge-llc/pigeon/pull/236))
-- Add ExpiredToken as an option for error response
+- Add ExpiredToken as an option for APNS error response
+- Improve handling of FCM error responses
 - Use a fork of Kadabra to fix ssl_error
 - Fix httpoison dependency not resolving 2.0
 

--- a/lib/pigeon/fcm/error.ex
+++ b/lib/pigeon/fcm/error.ex
@@ -5,6 +5,9 @@ defmodule Pigeon.FCM.Error do
 
   @doc false
   @spec parse(map) :: Notification.error_response()
+  def parse(%{"details" => [%{"errorCode" => error_code}]}),
+    do: parse_response(error_code)
+
   def parse(error) do
     error
     |> Map.get("status")
@@ -19,5 +22,5 @@ defmodule Pigeon.FCM.Error do
   defp parse_response("UNAVAILABLE"), do: :unavailable
   defp parse_response("INTERNAL"), do: :internal
   defp parse_response("THIRD_PARTY_AUTH_ERROR"), do: :third_party_auth_error
-  defp parse_response(_), do: :unknown_error
+  defp parse_response(_other), do: :unknown_error
 end

--- a/lib/pigeon/fcm/notification.ex
+++ b/lib/pigeon/fcm/notification.ex
@@ -40,6 +40,7 @@ defmodule Pigeon.FCM.Notification do
           | :unavailable
           | :internal
           | :third_party_auth_error
+          | :unknown_error
 
   @typedoc ~S"""
   FCM notification target. Must be one of the following:

--- a/test/pigeon/adm/result_parser_test.exs
+++ b/test/pigeon/adm/result_parser_test.exs
@@ -11,7 +11,6 @@ defmodule Pigeon.ADM.ResultParserTest do
     Pigeon.ADM.ResultParser.parse(n, %{"reason" => "InvalidExpiration"})
     Pigeon.ADM.ResultParser.parse(n, %{"reason" => "InvalidChecksum"})
     Pigeon.ADM.ResultParser.parse(n, %{"reason" => "InvalidType"})
-    Pigeon.ADM.ResultParser.parse(n, %{"reason" => "ExpiredToken"})
     Pigeon.ADM.ResultParser.parse(n, %{"reason" => "Unregistered"})
     Pigeon.ADM.ResultParser.parse(n, %{"reason" => "AccessTokenExpired"})
     Pigeon.ADM.ResultParser.parse(n, %{"reason" => "MessageTooLarge"})


### PR DESCRIPTION
Improve FCM error handling by looking first at the errorCode, which is more informative than just the status.