### PR TITLE
Change the :stop clause to work on all returns, not just timeout

### DIFF
--- a/lib/pigeon/dispatcher_worker.ex
+++ b/lib/pigeon/dispatcher_worker.ex
@@ -18,8 +18,8 @@ defmodule Pigeon.DispatcherWorker do
       {:error, reason} ->
         {:error, reason}
 
-      {:stop, :timeout} ->
-        {:stop, :timeout}
+      {:stop, reason} ->
+        {:stop, reason}
     end
   end
 


### PR DESCRIPTION
This fixes the clause still not matching certain returns such as `{:stop {:nxdomain, ...}}`